### PR TITLE
Added chrome.runtime.error check during web auth flow.

### DIFF
--- a/dropbox_client.js
+++ b/dropbox_client.js
@@ -25,7 +25,10 @@
       "url": AUTH_URL,
       "interactive": true
     }, function(redirectUrl) {
-      console.log(redirectUrl);
+      if (chrome.runtime.lastError) {
+        errorCallback(chrome.runtime.lastError.message);
+        return;
+      }
       if (redirectUrl) {
         var parametersStr = redirectUrl.substring(redirectUrl.indexOf("#") + 1);
         var parameters = parametersStr.split("&");


### PR DESCRIPTION
Without that, my background page was screaming when my redirect URL was not set up properly in my dropbox app console ;)

![image](https://cloud.githubusercontent.com/assets/634478/6187718/6fc99b2a-b38a-11e4-8a9c-1b5b2154bbd8.png)
